### PR TITLE
Add client and server type aliases

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,5 +24,10 @@ pub mod tonic {
 
 pub use self::proto::{inx_client as client, inx_server as server};
 
+/// TODO
+pub type InxClient = client::InxClient<tonic::Channel>;
+/// TODO
+pub type InxServer = server::InxServer<tonic::Channel>;
+
 #[cfg(feature = "types")]
 pub use self::types::*;


### PR DESCRIPTION
Adds some convenience type aliases to reduce a bit of noise in `inx-chronicle`.